### PR TITLE
[Conda] Add Python-lark to all three platforms

### DIFF
--- a/conda/linux/create_bundle.sh
+++ b/conda/linux/create_bundle.sh
@@ -11,7 +11,7 @@ echo -e "\nCreate the environment"
 packages="freecad=*.pre occt vtk python=3.10 blas=*=openblas numpy \
           matplotlib-base scipy sympy pandas six pyyaml pycollada lxml \
           xlutils olefile requests blinker opencv qt.py nine docutils \
-          opencamlib calculix ifcopenshell appimage-updater-bridge"
+          opencamlib calculix ifcopenshell lark appimage-updater-bridge"
 #if [[ "$ARCH" = "x86_64" ]]; then
 #  packages=${packages}" ifcopenshell appimage-updater-bridge"
 #fi

--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -9,7 +9,7 @@ mamba create \
     -p ${conda_env} \
     freecad=*.pre occt vtk python=3.10 calculix blas=*=openblas \
     numpy matplotlib-base scipy sympy pandas six \
-    pyyaml jinja2 opencamlib ifcopenshell \
+    pyyaml jinja2 opencamlib ifcopenshell lark \
     pycollada lxml xlutils olefile requests \
     blinker opencv qt.py nine docutils \
     --copy -c freecad/label/dev -c conda-forge -y

--- a/conda/win/create_bundle.bat
+++ b/conda/win/create_bundle.bat
@@ -7,7 +7,7 @@ call mamba create ^
  -p %conda_env% ^
  freecad=*.pre python=3.10 occt vtk calculix gmsh ^
  numpy matplotlib-base scipy sympy pandas six ^
- pyyaml opencamlib ifcopenshell ^
+ pyyaml opencamlib ifcopenshell lark ^
  pycollada lxml xlutils olefile requests ^
  blinker opencv qt.py nine docutils ^
  --copy ^


### PR DESCRIPTION
See forum discussion https://forum.freecad.org/viewtopic.php?t=84536 it appears that `ifcopenshell` doesn't bring in the lark dependency, therefore adding to the bundles.